### PR TITLE
chore: updated shell script to accept one URI only for IE input

### DIFF
--- a/shell/run_bacalhau.sh
+++ b/shell/run_bacalhau.sh
@@ -12,8 +12,8 @@ LATEST_DOCKER_IMAGE_DIGEST=`awk -F',"digest":"|","os"' '{print $2}' <<< "$IMAGE_
 
 # Constants
 DOCKER_IMAGE=${DOCKER_NAME}/$IMAGE_NAME@$LATEST_DOCKER_IMAGE_DIGEST
-DEFAULT_HTTPS_URL=https://nftstorage.link/ipfs/bafybeihjfez2hb2i2bdpwkegxopzu6teqmgwnbxqhukjl7brmgwppipnwa
-DEFAULT_IPFS_CID=bafybeihjfez2hb2i2bdpwkegxopzu6teqmgwnbxqhukjl7brmgwppipnwa
+DEFAULT_HTTPS_URL=https://gateway.pinata.cloud/ipfs/QmfCM4tpAL5jQGdnjdkTXkeJDhpCs7kJDJYupyY88UhuPT
+DEFAULT_IPFS_CID=QmfCM4tpAL5jQGdnjdkTXkeJDhpCs7kJDJYupyY88UhuPT
 OUTPUT_FOLDER=results
 
 # create results directory
@@ -37,21 +37,17 @@ echo "Running Docker image on Bacalhau"
 if [ $INPUT_URL_TYPE == "A" -o $INPUT_URL_TYPE == "a" ]
 then
    # Read Input URL (HTTPS)
-    echo "Provide IPFS Input for data.json:"
+    echo "Provide IPFS Input:"
     read INPUT_DATA_CID
-    echo "Provide IPFS Input for trustedSeed.json:"
-    read INPUT_TRUSTED_CID
     echo "Running Docker Image on Bacalhau..."
-    JOB_OUTPUT=`bacalhau docker run --inputs $INPUT_DATA_CID --inputs $INPUT_TRUSTED_CID $DOCKER_IMAGE`
+    JOB_OUTPUT=`bacalhau docker run --inputs $INPUT_DATA_CID $DOCKER_IMAGE`
 elif [ $INPUT_URL_TYPE == "B" -o $INPUT_URL_TYPE == "b" ]
 then
    # Read Input URL (HTTPS)
-    echo "Provide HTTPs Input for data.json:"
+    echo "Provide HTTPs Input:"
     read INPUT_DATA_URL
-    echo "Provide HTTPs Input for trustedSeed.json:"
-    read INPUT_TRUSTED_URL
     echo "Running Docker Image on Bacalhau..."
-    JOB_OUTPUT=`bacalhau docker run -u $INPUT_DATA_URL -u $INPUT_TRUSTED_URL $DOCKER_IMAGE`
+    JOB_OUTPUT=`bacalhau docker run -u $INPUT_DATA_URL $DOCKER_IMAGE`
 elif [ $INPUT_URL_TYPE == "C" -o $INPUT_URL_TYPE == "c" ]
 then
    # Run docker image with no input
@@ -63,7 +59,7 @@ then
    # Run docker image with default HTTPs input
    echo "Default HTTPs Input"
    echo "Running Docker Image on Bacalhau..."
-   JOB_OUTPUT=`bacalhau docker run -u $DEFAULT_HTTPS_URL/data.json -u $DEFAULT_HTTPS_URL/trustedSeed.json $DOCKER_IMAGE`
+   JOB_OUTPUT=`bacalhau docker run -u $DEFAULT_HTTPS_URL $DOCKER_IMAGE`
 elif [ $INPUT_URL_TYPE == "E" -o $INPUT_URL_TYPE == "e" ]
 then
    # run docker image with default IPFS input


### PR DESCRIPTION
What I have Done:
1. Updated script to only accept one URI in this format:
```json
{
  "data": {},
  "trustedSeed": [],
  "previousRewards": "",
  "otherData": {},
}
```
3. Updated the default URI to be used.